### PR TITLE
Added compatibility with other mod-opened carpenter menus

### DIFF
--- a/BetterJunimos/BetterJunimos.cs
+++ b/BetterJunimos/BetterJunimos.cs
@@ -125,9 +125,13 @@ namespace BetterJunimos {
             
             // opened menu
             else if (e.OldMenu == null && e.NewMenu is CarpenterMenu) {
-                // limit to only junimo hut
-                if (!Game1.MasterPlayer.mailReceived.Contains("hasPickedUpMagicInk")) {
-                    OpenJunimoHutMenu();
+                if (Helper.Reflection.GetField<bool>(e.NewMenu, "magicalConstruction").GetValue())
+                {
+                    // limit to only junimo hut
+                    if (!Game1.MasterPlayer.mailReceived.Contains("hasPickedUpMagicInk"))
+                    {
+                        OpenJunimoHutMenu();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Right now, other mods that open up a carpenter menu while Better Junimos is installed, before getting the magic ink quest mail, will replace that menu with the junimo hut menu.

This PR adds an additional check to ensure that the menu opened is a wizard building menu before overriding it