### PR TITLE
Avoid using ___netHome if unnecessary in patch functions

### DIFF
--- a/BetterJunimos/Patches/JunimoHarvesterPatches.cs
+++ b/BetterJunimos/Patches/JunimoHarvesterPatches.cs
@@ -106,8 +106,10 @@ namespace BetterJunimos.Patches {
     // pathfindToRandomSpotAroundHut
     // Expand radius of random pathfinding
     public class PatchPathfindToRandomSpotAroundHut {
-        public static void Postfix(JunimoHarvester __instance, ref NetGuid ___netHome) {
-            var hut = Util.GetHutFromId(___netHome.Value);
+        public static void Postfix(JunimoHarvester __instance) {
+            var hut = __instance.home;
+            if (hut is null) return;
+
             var radius = Util.CurrentWorkingRadius;
             var retry = 0;
             do {
@@ -179,11 +181,13 @@ namespace BetterJunimos.Patches {
     // Remove the max distance boundary
     [HarmonyPriority(Priority.Low)]
     public class PatchPathfindDoWork {
-        public static bool Prefix(JunimoHarvester __instance, ref NetGuid ___netHome,
+        public static bool Prefix(JunimoHarvester __instance,
             ref NetEvent1Field<int, NetInt> ___netAnimationEvent) {
             if (!Context.IsMainPlayer) return true;
 
-            var hut = Util.GetHutFromId(___netHome.Value);
+            var hut = __instance.home;
+            if (hut is null) return true;
+
             var quittingTime = Util.Progression.CanWorkInEvenings ? 2400 : 1900;
 
             // BetterJunimos.SMonitor.Log($"PatchPathfindDoWork: Junimo {__instance.whichJunimoFromThisHut} in {__instance.currentLocation.Name} looking for work", LogLevel.Debug);


### PR DESCRIPTION
Instead of using ___netHome in the PatchPathfindToRandomSpotAroundHut
and PatchPathfindDoWork patch functions, notice that __instance has a
home public getter/setter which does a more robust home/hut lookup. The
__instance.home will take into account the current location, and returns
null if the home has not been set for a given Junimo.

It is preferable to use the real game logic if possible, so there's no
reason to be re-implementing the Guid->JunimoHut lookup if unnecessary.

Use this and also check the null value and stop the patch functions if
we don't have a valid home.

A bunch of other places in the code rely on the Guid values directly
such as for putting into maps. I did not attempt to change those places.
I suspect that the 1.6 code changes to support buildings at more
locations than just the farm will cause issues, as a ton of code in the
BetterJunimos logic relies on the assumption that all Junimo Huts are at
the farm. This is probably ok for now, but we might want to figure out a
more robust solution.

This change should hopefully fix issues similar to the following:

[02:36:24 ERROR game] An error occurred in the base update loop: System.Collections.Generic.KeyNotFoundException: The given key '00000000-0000-0000-0000-000000000000' was not present in the dictionary.
at BetterJunimos.Utils.Util.GetHutFromId(Guid id)
at BetterJunimos.Patches.PatchPathfindToRandomSpotAroundHut.Postfix(JunimoHarvester __instance, NetGuid& ___netHome)
at StardewValley.Characters.JunimoHarvester.pathfindToRandomSpotAroundHut_PatchedBy<com.hawkfalcon.BetterJunimos>(JunimoHarvester this)
at StardewValley.Characters.JunimoHarvester..ctor(GameLocation location, Vector2 position, JunimoHut hut, Int32 whichJunimoNumberFromThisHut, Nullable1 c) at BetterJunimos.Utils.Util.SpawnJunimoAtPosition(GameLocation location, Vector2 pos, JunimoHut hut, Int32 junimoNumber) at BetterJunimos.Abilities.VisitGreenhouseAbility.PerformAction(GameLocation location, Vector2 pos, JunimoHarvester junimo, Guid guid) at BetterJunimos.Patches.PatchTryToHarvestHere.Prefix(JunimoHarvester __instance, Int32& ___harvestTimer, NetGuid& ___netHome) at StardewValley.Characters.JunimoHarvester.tryToHarvestHere_PatchedBy<com.hawkfalcon.BetterJunimos>(JunimoHarvester this) at StardewValley.Pathfinding.PathFindController.moveCharacter(GameTime time) at StardewValley.Pathfinding.PathFindController.update(GameTime time) at StardewValley.Character.update(GameTime time, GameLocation location, Int64 id, Boolean move) at StardewValley.Character.update(GameTime time, GameLocation location) at StardewValley.NPC.update(GameTime time, GameLocation location) at StardewValley.Characters.JunimoHarvester.update_PatchedBy<com.hawkfalcon.BetterJunimos>(JunimoHarvester this, GameTime time, GameLocation location) at StardewValley.GameLocation.updateCharacters(GameTime time) at StardewValley.GameLocation.updateEvenIfFarmerIsntHere(GameTime time, Boolean ignoreWasUpdatedFlush) at StardewValley.Game1._UpdateLocation(GameLocation location, GameTime time) at StardewValley.Game1.<>c__DisplayClass707_0.<UpdateLocations>b__0(GameLocation location) at StardewValley.Utility.ForEachLocation(Func2 action, Boolean includeInteriors, Boolean includeGenerated)
at StardewValley.Game1.UpdateLocations(GameTime time)
at StardewValley.Game1._update(GameTime gameTime)
at StardewValley.Game1.Update(GameTime gameTime)
at StardewModdingAPI.Framework.SCore.OnPlayerInstanceUpdating(SGame instance, GameTime gameTime, Action runUpdate)

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
