### PR TITLE
Fix Item Category Logic for BetterJunimos

### DIFF
--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -236,16 +236,19 @@ namespace BetterJunimos.Utils {
                 }
 
                 if (!itemId.StartsWith("-")) {
-                    ItemsInHuts[id][itemId] = chest.Items.Any(item =>
-                        item != null && item.ItemId.ToString() == itemId &&
-                        !(BetterJunimos.Config.JunimoImprovements.AvoidPlantingCoffee &&
-                          item.ParentSheetIndex == Util.CoffeeId)
-                    );
+                    UpdateHutContainsItemId(id, chest, itemId);
                 }
                 else {
                     UpdateHutContainsItemCategory(id, chest, itemId);
                 }
             }
+        }
+
+        private static void UpdateHutContainsItemId(Guid id, Chest chest, string itemId) {
+            ItemsInHuts[id][itemId] = chest.Items.Any(item =>
+                item != null && item.ItemId.ToString() == itemId &&
+                !(BetterJunimos.Config.JunimoImprovements.AvoidPlantingCoffee && item.ParentSheetIndex == Util.CoffeeId)
+            );
         }
 
         private static void UpdateHutContainsItemCategory(Guid id, Chest chest, string itemCategory) {

--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -249,10 +249,6 @@ namespace BetterJunimos.Utils {
         }
 
         private static void UpdateHutContainsItemCategory(Guid id, Chest chest, string itemCategory) {
-            if (!ItemsInHuts.ContainsKey(id)) {
-                ItemsInHuts.Add(id, new Dictionary<string, bool>());
-            }
-
             ItemsInHuts[id][itemCategory] = chest.Items.Any(item =>
                 item != null && item.Category.ToString() == itemCategory &&
                 !(BetterJunimos.Config.JunimoImprovements.AvoidPlantingCoffee && item.ParentSheetIndex == Util.CoffeeId)

--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -235,7 +235,7 @@ namespace BetterJunimos.Utils {
                     ItemsInHuts.Add(id, new Dictionary<string, bool>());
                 }
 
-                if (itemId != "0") {
+                if (!itemId.StartsWith("-")) {
                     ItemsInHuts[id][itemId] = chest.Items.Any(item =>
                         item != null && item.ItemId.ToString() == itemId &&
                         !(BetterJunimos.Config.JunimoImprovements.AvoidPlantingCoffee &&

--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -235,12 +235,11 @@ namespace BetterJunimos.Utils {
                     ItemsInHuts.Add(id, new Dictionary<string, bool>());
                 }
 
-                if (!itemId.StartsWith("-")) {
-                    UpdateHutContainsItemId(id, chest, itemId);
-                }
-                else {
+                // item categories start with a -
+                if (itemId.StartsWith("-"))
                     UpdateHutContainsItemCategory(id, chest, itemId);
-                }
+                else
+                    UpdateHutContainsItemId(id, chest, itemId);
             }
         }
 


### PR DESCRIPTION
The first commit fixes the logic for handling item categories. The later
commits are cleanup and refactor which I think makes the resulting code
easier to understand.

This is a critical fix as currently the Junimos will not perform any action
which requires items without it.

- **Fix UpdateHutContainsItems check for item categories**
- **remove unnecessary duplicate dictionary creation logic**
- **extract ItemsInHuts update logic to UpdateHutContainsItemId**
- **remove needless negation in UpdateHutContainsItems**
