### PR TITLE
Fix building cost reduction logic

### DIFF
--- a/BetterJunimos/BetterJunimos.cs
+++ b/BetterJunimos/BetterJunimos.cs
@@ -43,7 +43,7 @@ namespace BetterJunimos {
             Util.Progression = new JunimoProgression(ModManifest, Monitor, Helper);
             Util.Greenhouse = new JunimoGreenhouse(ModManifest, Monitor, Helper);
             
-            helper.Events.Content.AssetRequested += BlueprintEditor.OnAssetRequested;
+            helper.Events.Content.AssetRequested += BuildingEditor.OnAssetRequested;
             helper.Events.Content.AssetRequested += JunimoEditor.OnAssetRequested;
 
             helper.Events.GameLoop.OneSecondUpdateTicked += Util.Progression.ConfigureFromWizard;

--- a/BetterJunimos/BetterJunimos.cs
+++ b/BetterJunimos/BetterJunimos.cs
@@ -630,8 +630,8 @@ namespace BetterJunimos {
             SHelper.WriteConfig(Config);
             SHelper.GameContent.InvalidateCache("Characters/Junimo");
             SHelper.GameContent.InvalidateCache($"Characters/Junimo.{SHelper.Translation.Locale}");
-            SHelper.GameContent.InvalidateCache("Data/Blueprints");
-            SHelper.GameContent.InvalidateCache($"Data/Blueprints.{SHelper.Translation.Locale}");
+            SHelper.GameContent.InvalidateCache("Data/Buildings");
+            SHelper.GameContent.InvalidateCache($"Data/Buildings.{SHelper.Translation.Locale}");
         }
 
         private static void AllowJunimoHutPurchasing() {

--- a/BetterJunimos/BuildingEditor.cs
+++ b/BetterJunimos/BuildingEditor.cs
@@ -1,29 +1,42 @@
 ﻿using BetterJunimos.Utils;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
+using StardewValley.GameData.Buildings;
+using System.Linq;
 
 namespace BetterJunimos {
     public static class BuildingEditor {
         private const string hutKey = "Junimo Hut";
 
         internal static void OnAssetRequested(object sender, AssetRequestedEventArgs e) {
-            if (e.NameWithoutLocale.IsEquivalentTo("Data/Blueprints")) {
+            if (e.NameWithoutLocale.IsEquivalentTo("Data/Buildings")) {
                 e.Edit(asset => {
-                    var data = asset.AsDictionary<string, string>().Data;
+                    var data = asset.AsDictionary<string, StardewValley.GameData.Buildings.BuildingData>().Data;
+                    var junimoHut = data[hutKey];
 
                     if (BetterJunimos.Config.JunimoHuts.FreeToConstruct) {
-                        var fields = data[hutKey].Split('/');
-                        fields[0] = "";
-                        fields[17] = "0";
-                        data[hutKey] = string.Join("/", fields);
-                        BetterJunimos.SMonitor.Log(data[hutKey], LogLevel.Debug);
-                    }
-                    else if (Util.Progression.ReducedCostToConstruct) {
-                        var fields = data[hutKey].Split('/');
-                        fields[0] = "390 100 268 3 771 100";
-                        fields[17] = "10000";
-                        data[hutKey] = string.Join("/", fields);
-                        BetterJunimos.SMonitor.Log(data[hutKey], LogLevel.Debug);
+
+                        junimoHut.BuildCost = 0;
+                        junimoHut.BuildMaterials.Clear();
+                        BetterJunimos.SMonitor.Log($"Edited Junimo Huts to cost ${junimoHut.BuildCost} and no materials", LogLevel.Debug);
+                    } else if (Util.Progression.ReducedCostToConstruct) {
+                        junimoHut.BuildCost = 10000;
+                        junimoHut.BuildMaterials.Clear();
+
+                        junimoHut.BuildMaterials.Add(new BuildingMaterial {
+                            ItemId = "390",
+                            Amount = 100
+                        });
+                        junimoHut.BuildMaterials.Add(new BuildingMaterial {
+                            ItemId = "268",
+                            Amount = 3
+                        });
+                        junimoHut.BuildMaterials.Add(new BuildingMaterial {
+                            ItemId = "771",
+                            Amount = 100
+                        });
+                        var materials = string.Join(" / ", from material in junimoHut.BuildMaterials select $"{material.ItemId} {material.Amount}");
+                        BetterJunimos.SMonitor.Log($"Edited Junimo Huts to cost ${junimoHut.BuildCost}, with materials {materials}", LogLevel.Debug);
                     }
                 });
             }

--- a/BetterJunimos/BuildingEditor.cs
+++ b/BetterJunimos/BuildingEditor.cs
@@ -3,7 +3,7 @@ using StardewModdingAPI;
 using StardewModdingAPI.Events;
 
 namespace BetterJunimos {
-    public static class BlueprintEditor {
+    public static class BuildingEditor {
         private const string hutKey = "Junimo Hut";
 
         internal static void OnAssetRequested(object sender, AssetRequestedEventArgs e) {

--- a/BetterJunimos/Utils/JunimoProgression.cs
+++ b/BetterJunimos/Utils/JunimoProgression.cs
@@ -61,14 +61,20 @@ namespace BetterJunimos.Utils {
         }
 
         private bool Unlocked(string progression) {
-            var farm = Game1.getFarm();
-            if (farm == null) return false;
-            var k = $"hawkfalcon.BetterJunimos.ProgressionData.{progression}.Unlocked";
-            if (farm.modData.TryGetValue(k, out var v)) {
-                return v == "1";
-            }
+            try {
+                var farm = Game1.getFarm();
 
-            return false;
+                if (farm == null) return false;
+                var k = $"hawkfalcon.BetterJunimos.ProgressionData.{progression}.Unlocked";
+                if (farm.modData.TryGetValue(k, out var v)) {
+                    return v == "1";
+                }
+
+                return false;
+            } catch (Exception e) {
+                _monitor.Log($"Unlocked: {e}", LogLevel.Trace);
+                return false;
+            }
         }
 
         public void SetUnlocked(string progression) {


### PR DESCRIPTION
This series should fix the building cost reduction logic for Junimo huts. I
updated the code to point at Data/Buildings instead of Data/Blueprints, and
fixed how we edit the materials.

- **Rename BlueprintEditor to BuildingEditor**
- **catch exceptions in Unlocked() for JunimoProgression**
- **Update logic for Junimo Hut cost reduction to Stardew 1.6**
