### PR TITLE
Fixed the Junimos' inability to plant, as I set out to do

### DIFF
--- a/BetterJunimos/Abilities/Base/PlantCropsAbility.cs
+++ b/BetterJunimos/Abilities/Base/PlantCropsAbility.cs
@@ -69,7 +69,7 @@ namespace BetterJunimos.Abilities {
 
             // BetterJunimos.SMonitor.Log(
             //     $"PerformAction planting {foundItem.Name} in {location.Name} at at [{pos.X} {pos.Y}]", LogLevel.Debug);
-            if (Plant(location, pos, foundItem.itemId.ToString())) {
+            if (Plant(location, pos, foundItem.ItemId)) {
                 Util.RemoveItemFromChest(chest, foundItem);
                 // BetterJunimos.SMonitor.Log(
                     // $"PerformAction planted {foundItem.Name} in {location.Name} at at [{pos.X} {pos.Y}]", LogLevel.Debug);
@@ -85,9 +85,8 @@ namespace BetterJunimos.Abilities {
         /// <summary>Get an item from the chest that is a crop seed, plantable in this season</summary>
         private Item PlantableSeed(GameLocation location, Chest chest, string cropType=null) {
             var foundItems = chest.Items.ToList().FindAll(item =>
-                item != null 
-                && item.Category == ItemCategory
-                && !IsTreeSeed(item)
+                item != null
+                && (new StardewValley.Object(item.ItemId, 1)).Type == "Seeds"
                 && !(BetterJunimos.Config.JunimoImprovements.AvoidPlantingCoffee && item.ParentSheetIndex == Util.CoffeeId)
             );
             
@@ -112,17 +111,17 @@ namespace BetterJunimos.Abilities {
                     continue;
                 }
                 
-                var key = foundItem.itemId;
+                var key = foundItem.ItemId;
                 try {
-                    if (cropSeasons[Game1.currentSeason][key.ToString()]) {
+                    if (cropSeasons[Game1.currentSeason][key]) {
                         return foundItem;
                     }
                 } catch (KeyNotFoundException)
                 {
                     // Monitor.Log($"Cache miss: {key} {Game1.currentSeason}", LogLevel.Debug);
-                    var crop = new Crop(foundItem.itemId.ToString(), 0, 0, location);
-                    cropSeasons[Game1.currentSeason][key.ToString()] = crop.IsInSeason(location);
-                    if (cropSeasons[Game1.currentSeason][key.ToString()]) {
+                    var crop = new Crop(key, 0, 0, location);
+                    cropSeasons[Game1.currentSeason][key] = crop.IsInSeason(location);
+                    if (cropSeasons[Game1.currentSeason][key]) {
                         return foundItem;
                     }
                 }
@@ -134,11 +133,11 @@ namespace BetterJunimos.Abilities {
         
         // TODO: look this up properly instead of keeping a list of base-game tree seed item IDs
         protected bool IsTreeSeed(Item item) {
-            return WildTreeSeeds.ContainsKey(item.itemId.ToString());
+            return WildTreeSeeds.ContainsKey(item.ItemId);
         }
 
         private bool IsTrellisCrop(Item item, GameLocation location) {
-            Crop crop = new Crop(item.itemId.ToString(), 0, 0, location);
+            Crop crop = new Crop(item.ItemId, 0, 0, location);
             return crop.raisedSeeds.Value;
         }
 

--- a/BetterJunimos/Abilities/Base/PlantCropsAbility.cs
+++ b/BetterJunimos/Abilities/Base/PlantCropsAbility.cs
@@ -21,7 +21,6 @@ namespace BetterJunimos.Abilities {
         private const string DeluxeSpeedGro = "466";
         private const string HyperSpeedGro = "918";
         
-        static Dictionary<string, int> WildTreeSeeds = new() {{"292", 8}, {"309", 1}, {"310", 2}, {"311", 3}, {"891", 7}};
         static Dictionary<string, Dictionary<string, bool>> cropSeasons = new();
         
         internal PlantCropsAbility(IMonitor Monitor) {
@@ -129,11 +128,6 @@ namespace BetterJunimos.Abilities {
             }
 
             return null;
-        }
-        
-        // TODO: look this up properly instead of keeping a list of base-game tree seed item IDs
-        protected bool IsTreeSeed(Item item) {
-            return WildTreeSeeds.ContainsKey(item.ItemId);
         }
 
         private bool IsTrellisCrop(Item item, GameLocation location) {

--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -245,7 +245,7 @@ namespace BetterJunimos.Utils {
 
         private static void UpdateHutContainsItemId(Guid id, Chest chest, string itemId) {
             ItemsInHuts[id][itemId] = chest.Items.Any(item =>
-                item != null && item.ItemId.ToString() == itemId &&
+                item != null && item.ItemId == itemId &&
                 !(BetterJunimos.Config.JunimoImprovements.AvoidPlantingCoffee && item.ParentSheetIndex == Util.CoffeeId)
             );
         }

--- a/BetterJunimos/Utils/JunimoProgression.cs
+++ b/BetterJunimos/Utils/JunimoProgression.cs
@@ -61,14 +61,20 @@ namespace BetterJunimos.Utils {
         }
 
         private bool Unlocked(string progression) {
-            var farm = Game1.getFarm();
-            if (farm == null) return false;
-            var k = $"hawkfalcon.BetterJunimos.ProgressionData.{progression}.Unlocked";
-            if (farm.modData.TryGetValue(k, out var v)) {
-                return v == "1";
-            }
+            try {
+                var farm = Game1.getFarm();
 
-            return false;
+                if (farm == null) return false;
+                var k = $"hawkfalcon.BetterJunimos.ProgressionData.{progression}.Unlocked";
+                if (farm.modData.TryGetValue(k, out var v)) {
+                    return v == "1";
+                }
+
+                return false;
+            } catch (Exception e) {
+                _monitor.Log($"Unlocked: {e}", LogLevel.Trace);
+                return false;
+            }
         }
 
         public void SetUnlocked(string progression) {
@@ -288,7 +294,7 @@ namespace BetterJunimos.Utils {
             // BetterJunimos.SMonitor.Log($"ReceiveItems wants {needed} of [{index}]", LogLevel.Debug);
             if (needed <= 0) return true;
 
-            var inChest = chest.Items.Where(item => item != null && item.itemId.ToString() == itemID).ToList();
+            var inChest = chest.Items.Where(item => item != null && item.ItemId == itemID).ToList();
 
             foreach (var itemStack in inChest) {
                 if (itemStack.Stack >= needed) {


### PR DESCRIPTION
Did this by changing item.itemId.ToString() to item.ItemId (Which is the same as item.itemId.Value)

Also changed PlantableSeed to use Object.Type == "Seeds"
Category -74(SeedsCategory) has 68 items. 52 are "Seeds" while the other 16 are trees or grow like them(Mossy Seed, Mushroom Tree)
The xnb on Crops has 50, I couldn't identify the 2 item discrepancy.

And then I removed the IsTreeSeed method and the WildTreeSeeds dictionary that are no longer referenced due to the above change.