### PR TITLE
Add support for additional farms

### DIFF
--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -215,7 +215,6 @@ namespace BetterJunimos.Utils {
         }
 
         private static bool ItemInHut(Guid id, string item) {
-            // BetterJunimos.SMonitor.Log($"Items in huts keys = ${string.Join(",", ItemsInHuts.Keys)}", LogLevel.Debug);
             return ItemsInHuts[id].TryGetValue(item, out var present) && present;
         }
 

--- a/BetterJunimos/Abilities/JunimoAbilities.cs
+++ b/BetterJunimos/Abilities/JunimoAbilities.cs
@@ -215,6 +215,7 @@ namespace BetterJunimos.Utils {
         }
 
         private static bool ItemInHut(Guid id, string item) {
+            // BetterJunimos.SMonitor.Log($"Items in huts keys = ${string.Join(",", ItemsInHuts.Keys)}", LogLevel.Debug);
             return ItemsInHuts[id].TryGetValue(item, out var present) && present;
         }
 

--- a/BetterJunimos/BetterJunimos.cs
+++ b/BetterJunimos/BetterJunimos.cs
@@ -297,8 +297,6 @@ namespace BetterJunimos {
                 // this might be getting called a bit too much
                 // but since OnMenuChanged doesn't tell us reliably which hut has changed
                 // it's safer to update items from all huts here
-                // SMonitor.Log($"Getting GUID for ${hut}...", LogLevel.Debug);
-                // SMonitor.Log($"\tGot GUID as ${Util.GetHutIdFromHut(hut)}", LogLevel.Debug);
                 Util.Abilities.UpdateHutItems(Util.GetHutIdFromHut(hut));
 
                 if (Config.JunimoPayment.WorkForWages) {

--- a/BetterJunimos/BetterJunimos.cs
+++ b/BetterJunimos/BetterJunimos.cs
@@ -647,7 +647,7 @@ namespace BetterJunimos {
             var currentLocation = Game1.player.currentLocation;
 
             if (currentLocation.IsFarm || currentLocation.IsGreenhouse) {
-                var junimoHuts = Util.getFarms()
+                var junimoHuts = Util.GetAllFarms()
                     .FindAll(farm => farm.Equals(currentLocation))
                     .SelectMany(farm => farm.buildings.OfType<JunimoHut>())
                     .ToList();

--- a/BetterJunimos/Patches/JunimoHutPatches.cs
+++ b/BetterJunimos/Patches/JunimoHutPatches.cs
@@ -40,7 +40,6 @@ namespace BetterJunimos.Patches {
         private static bool SearchAroundHut(JunimoHut hut) {
             var id = Util.GetHutIdFromHut(hut);
             var radius = Util.CurrentWorkingRadius;
-            // GameLocation farm = Game1.getFarm();
             GameLocation farm = Game1.currentLocation;
 
             // SearchHutGrid manages hut.lastKnownCropLocation and Util.Abilities.lastKnownCropLocations

--- a/BetterJunimos/Patches/JunimoHutPatches.cs
+++ b/BetterJunimos/Patches/JunimoHutPatches.cs
@@ -40,7 +40,8 @@ namespace BetterJunimos.Patches {
         private static bool SearchAroundHut(JunimoHut hut) {
             var id = Util.GetHutIdFromHut(hut);
             var radius = Util.CurrentWorkingRadius;
-            GameLocation farm = Game1.getFarm();
+            // GameLocation farm = Game1.getFarm();
+            GameLocation farm = Game1.currentLocation;
 
             // SearchHutGrid manages hut.lastKnownCropLocation and Util.Abilities.lastKnownCropLocations
             var foundWork = SearchHutGrid(hut, radius, farm, id);

--- a/BetterJunimos/Utils/JunimoProgression.cs
+++ b/BetterJunimos/Utils/JunimoProgression.cs
@@ -496,7 +496,7 @@ namespace BetterJunimos.Utils {
 
         
         public static bool HutOnTile(Vector2 pos) {
-            return Util.getFarms().Any(farm => farm.buildings.Any(b => b is JunimoHut && b.occupiesTile(pos)));
+            return Util.GetAllFarms().Any(farm => farm.buildings.Any(b => b is JunimoHut && b.occupiesTile(pos)));
         }
 
         private string Get(string key) {

--- a/BetterJunimos/Utils/JunimoProgression.cs
+++ b/BetterJunimos/Utils/JunimoProgression.cs
@@ -496,7 +496,7 @@ namespace BetterJunimos.Utils {
 
         
         public static bool HutOnTile(Vector2 pos) {
-            return Game1.getFarm().buildings.Any(b => b is JunimoHut && b.occupiesTile(pos));
+            return Util.getFarms().Any(farm => farm.buildings.Any(b => b is JunimoHut && b.occupiesTile(pos)));
         }
 
         private string Get(string key) {

--- a/BetterJunimos/Utils/Util.cs
+++ b/BetterJunimos/Utils/Util.cs
@@ -30,20 +30,8 @@ namespace BetterJunimos.Utils {
         internal static JunimoProgression Progression;
         internal static JunimoGreenhouse Greenhouse;
 
-        public static List<GameLocation> getFarms() {
-            // TODO: use the trick from Discord?
-
-            var farms = new List<GameLocation> { Game1.getFarm() };
-            
-            var ridgesideSummitFarm = Game1.getLocationFromName("Custom_Ridgeside_SummitFarm");
-            if (ridgesideSummitFarm != null) {
-                farms.Add(ridgesideSummitFarm);
-            }
-            
-            // BetterJunimos.SMonitor.Log($"Buildings found in main farm ${string.Join(",", farms[0].buildings)}", LogLevel.Debug);
-            // BetterJunimos.SMonitor.Log($"Buildings found in summit farm ${string.Join(",", farms[1].buildings)}", LogLevel.Debug);
-
-            return farms;
+        public static List<GameLocation> GetAllFarms() {
+            return Game1.locations.Where(loc => loc.IsFarm && loc.IsOutdoors).ToList();
         }
 
         public static int CurrentWorkingRadius {
@@ -55,15 +43,15 @@ namespace BetterJunimos.Utils {
         }
 
         public static List<JunimoHut> GetAllHuts() {
-            return getFarms().SelectMany(farm => farm.buildings.OfType<JunimoHut>().ToList()).ToList();
+            return GetAllFarms().SelectMany(farm => farm.buildings.OfType<JunimoHut>().ToList()).ToList();
         }
 
         public static Guid GetHutIdFromHut(JunimoHut hut) {
-            return getFarms().Select(farm => farm.buildings.GuidOf(hut)).ToList().Find(guid => guid != Guid.Empty);
+            return GetAllFarms().Select(farm => farm.buildings.GuidOf(hut)).ToList().Find(guid => guid != Guid.Empty);
         }
 
         public static JunimoHut GetHutFromId(Guid id) {
-            foreach (var farm in getFarms()) {
+            foreach (var farm in GetAllFarms()) {
                 if (farm.buildings.TryGetValue(id, out var hut)) {
                     return hut as JunimoHut;
                 }
@@ -71,7 +59,6 @@ namespace BetterJunimos.Utils {
             
             BetterJunimos.SMonitor.Log($"Could not get hut from id ${id}", LogLevel.Error);
             return null;
-            // return getFarms().Select(farm => farm.buildings[id]).ToList().Find(hut => hut != null) as JunimoHut;
         }
 
         public static void AddItemToChest(GameLocation farm, Chest chest, SObject item) {


### PR DESCRIPTION
I had a similar issue to #34 but with Ridgeside Village's Summit Farm, so this PR is an initial attempt to rectify this issue.

Junimo huts are now assumed to be able to exist on all game locations with `IsFarm` and `IsOutdoors` set to true, instead of only on the main `Game1.getFarm()` farm. I'm not sure if this is the most optimal solution, but it certainly is the simplest without necessitating a large refactor.

This PR is still incomplete as there are still calls to `Game1.getFarm()` that haven't been changed (mostly part of the progression logic), but I'm unsure as to whether or not changes are needed there so I've left them in for now.

I haven't done much comprehensive testing but the `ItemsInHuts` dictionary now seems to be populated correctly which solves all the `KeyNotFoundException: The given key '00000000-0000-0000-0000-000000000000' was not present in the dictionary.` errors being reported. The Junimos look like they're behaving on my Summit Farm at the very least, so I hope this PR is a good start :)