### PR TITLE
Fix Speed-Gro bonuses for crops planted by Junimos

### DIFF
--- a/BetterJunimos/Abilities/Base/PlantCropsAbility.cs
+++ b/BetterJunimos/Abilities/Base/PlantCropsAbility.cs
@@ -17,10 +17,6 @@ namespace BetterJunimos.Abilities {
         private readonly IMonitor Monitor;
 
         private const string SunflowerSeeds = "431";
-        private const string SpeedGro = "465";
-        private const string DeluxeSpeedGro = "466";
-        private const string HyperSpeedGro = "918";
-
         static Dictionary<string, Dictionary<string, bool>> cropSeasons = new();
 
         internal PlantCropsAbility(IMonitor Monitor) {
@@ -161,29 +157,18 @@ namespace BetterJunimos.Abilities {
             if (hd.crop == null) return;
 
             var paddyWaterCheck = hd.paddyWaterCheck();
-            var fertilizer = hd.fertilizer.Value is SpeedGro or DeluxeSpeedGro or HyperSpeedGro;
+            var fertilizerSpeedBoost = hd.GetFertilizerSpeedBoost();
             var agriculturalist = who.professions.Contains(5);
 
-            if (!(fertilizer || agriculturalist || paddyWaterCheck)) return;
+            if (fertilizerSpeedBoost <= 0 && !agriculturalist && !paddyWaterCheck) return;
 
             hd.crop.ResetPhaseDays();
             var num1 = 0;
             for (var index = 0; index < hd.crop.phaseDays.Count - 1; ++index) num1 += hd.crop.phaseDays[index];
-            var num2 = 0.0f;
-            switch (hd.fertilizer.Value) {
-                case "465":
-                    num2 += 0.1f;
-                    break;
-                case "466":
-                    num2 += 0.25f;
-                    break;
-                case "918":
-                    num2 += 0.33f;
-                    break;
-            }
+            var num2 = fertilizerSpeedBoost;
 
             if (paddyWaterCheck) num2 += 0.25f;
-            if (who.professions.Contains(5)) num2 += 0.1f;
+            if (agriculturalist) num2 += 0.1f;
             var num3 = (int)Math.Ceiling((double)num1 * num2);
             for (var index1 = 0; num3 > 0 && index1 < 3; ++index1) {
                 for (var index2 = 0; index2 < hd.crop.phaseDays.Count; ++index2) {


### PR DESCRIPTION
## Summary

Fixes #106.

This PR updates `PlantCropsAbility.applySpeedIncreases` to use Stardew Valley 1.6's built-in `HoeDirt.GetFertilizerSpeedBoost()` instead of manually checking hardcoded Speed-Gro item IDs.
This fix was prepared with GPT assistance.

## Root Cause

Better Junimos plants crops by manually creating a `Crop` and assigning it to `HoeDirt.crop`, then runs its own copied speed-growth logic.

That copied logic only recognized legacy unqualified fertilizer IDs:

- `"465"` for Speed-Gro
- `"466"` for Deluxe Speed-Gro
- `"918"` for Hyper Speed-Gro

In Stardew Valley 1.6, `HoeDirt.fertilizer.Value` can be either an unqualified item ID like `"465"` or a qualified item ID like `"(O)465"`. When the player applies Speed-Gro before Junimos plant the crop, the fertilizer value may be stored as a qualified ID, so the old hardcoded check fails and the crop does not receive the growth speed bonus.

## Changes

- Removed the hardcoded Speed-Gro ID constants from `PlantCropsAbility`.
- Replaced manual fertilizer ID checks with `hd.GetFertilizerSpeedBoost()`.
- Kept the existing paddy crop and Agriculturist profession bonuses.
- Reused the existing phase-day reduction logic, only changing how the fertilizer speed boost is detected.

## Why This Fix

Using `HoeDirt.GetFertilizerSpeedBoost()` delegates fertilizer handling back to the game, which already understands both qualified and unqualified item IDs. This also improves compatibility with custom fertilizers or future changes to fertilizer behavior.

## Testing

- Ran `git diff --check`.
- Local build reached DLL generation, but the final ModBuildConfig deploy step failed because my local `Mods/BetterJunimos/BetterJunimos.dll` was locked by another process. The failure was in deployment, not in this source change.